### PR TITLE
Revert "Add CNAME"

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-infoseciitr.in


### PR DESCRIPTION
Removing CNAME because the repository from which pull #6 was made had claimed the infoseciitr.in domain.